### PR TITLE
Load all the objects by stepping the webservice repeatedly.

### DIFF
--- a/ting.client.inc
+++ b/ting.client.inc
@@ -109,23 +109,25 @@ function ting_get_objects($ids) {
       $query[] = 'rec.id=' . $id;
     }
   }
+  // opensearch is limited to 50 results per call, so iterate until all have been fetched.
   $i = 0;
   do {
+    // I query is empty, then don't do it.
+    // Not necessary to do in each iteration, but it doesn't hurt much.
     if (sizeof($query) == 0) {
       break;
     }
-    $request = ting_get_request_factory()->getSearchRequest();
 
+    $request = ting_get_request_factory()->getSearchRequest();
     if ($agency = variable_get('ting_agency', FALSE)) {
       $request->setAgency($agency);
     }
-
     $profile = variable_get('ting_search_profile', '');
     if (!empty($profile) && method_exists($request, 'setProfile')) {
       $request->setProfile($profile);
     }
-
     $request->setQuery(join(' OR ', $query));
+    // Do it in steps of 50.
     $request->setStart($i * 50 + 1);
     $request->setNumResults(50);
     $request->setAllObjects(TRUE);


### PR DESCRIPTION
Yes, this will be slow for large lists! We might consider inserting a pager in the frontend.
But it is nicer than the current loan lists missing some titles when the limit of 50 uncached objects are hit.
opensearch limits stepValue to 50 (even though it doesn't say so in the documentation)...
