### PR TITLE
Print classification text.

### DIFF
--- a/ting.entities.inc
+++ b/ting.entities.inc
@@ -55,7 +55,7 @@ class TingEntity extends DingEntity {
   }
 
   function getClassification() {
-    $ret = (isset($this->reply->record['dc:subject']['dkdcplus:DK5'][0]) ? $this->reply->record['dc:subject']['dkdcplus:DK5'][0] : '' .
+    $ret = ((isset($this->reply->record['dc:subject']['dkdcplus:DK5'][0]) ? $this->reply->record['dc:subject']['dkdcplus:DK5'][0] : '') .
 	    (isset($this->reply->record['dc:subject']['dkdcplus:DK5-Text']) ? ' (' . $this->reply->record['dc:subject']['dkdcplus:DK5-Text'][0] . ')' : ''));
     if( strlen($ret) > 0 ) {
       return $ret;


### PR DESCRIPTION
Previously the text was only printed if there was no classification numbers.
I am guessing that means the text was never printed.
