### PR TITLE
Issue1113 by Pjohans: Set and use default (best match) sort method from ...

### DIFF
--- a/ting.admin.inc
+++ b/ting.admin.inc
@@ -162,6 +162,22 @@ function ting_admin_ranking_settings($form, &$form_state) {
     ),
   );
 
+
+  $ting_sort_value = variable_get('ting_sort_default', 'rank_frequency');
+  $form['ting_sort_default'] = array(
+    '#title' => t('Default sort method (best match)'),
+    '#type' => 'fieldset',
+    '#prefix' => '<div id="sort-default-fields-wrapper">',
+    '#suffix' => '</div>',
+    '#tree' => TRUE,
+  );
+
+  $form['ting_sort_default']['fields'] = array(
+    '#type' => 'ting_sort_default',
+    '#default_value' => array('sort_type' => $ting_sort_value),
+  );
+
+
   $form['buttons']['save'] = array(
     '#type' => 'submit',
     '#value' => t('Save changes'),
@@ -200,7 +216,6 @@ function ting_admin_ranking_add_more_js($form, &$form_state) {
  */
 function ting_admin_ranking_form_after_build($form, &$form_state) {
   $path = drupal_get_path('module', 'ting');
-
   drupal_add_css($path . '/css/ting_admin_ranking_form.css');
 
   return $form;
@@ -218,6 +233,11 @@ function ting_admin_ranking_settings_submit($form, &$form_state) {
   usort($fields, '_ting_ranking_field_sort');
 
   variable_set('ting_ranking_fields', $fields);
+
+  $default_sort = $form_state['values']['ting_sort_default']['fields']['sort_type'];
+  variable_set('ting_sort_default',$default_sort);
+
+  drupal_set_message(t('Settings has been saved'), 'status');
 }
 
 /**

--- a/ting.admin.inc
+++ b/ting.admin.inc
@@ -167,8 +167,6 @@ function ting_admin_ranking_settings($form, &$form_state) {
   $form['ting_sort_default'] = array(
     '#title' => t('Default sort method (best match)'),
     '#type' => 'fieldset',
-    '#prefix' => '<div id="sort-default-fields-wrapper">',
-    '#suffix' => '</div>',
     '#tree' => TRUE,
   );
 
@@ -235,7 +233,7 @@ function ting_admin_ranking_settings_submit($form, &$form_state) {
   variable_set('ting_ranking_fields', $fields);
 
   $default_sort = $form_state['values']['ting_sort_default']['fields']['sort_type'];
-  variable_set('ting_sort_default',$default_sort);
+  variable_set('ting_sort_default', $default_sort);
 
   drupal_set_message(t('Settings has been saved'), 'status');
 }

--- a/ting.admin.inc
+++ b/ting.admin.inc
@@ -170,8 +170,14 @@ function ting_admin_ranking_settings($form, &$form_state) {
     '#tree' => TRUE,
   );
 
-  $form['ting_sort_default']['fields'] = array(
-    '#type' => 'ting_sort_default',
+  $form['ting_sort_default']['fields']['sort_type'] = array(
+    '#title' => t('Type'),
+    '#type' => 'select',
+    '#options' => array(
+      'rank_frequency' => t('Best match'),
+      'rank_general' => t('General Rank'),
+      'rank_none' => t('No rank'),
+    ),
     '#default_value' => array('sort_type' => $ting_sort_value),
   );
 

--- a/ting.client.inc
+++ b/ting.client.inc
@@ -255,6 +255,11 @@ function ting_do_search($query, $page = 1, $results_per_page = 10, $options = ar
   if (isset($options['sort']) && $options['sort']) {
     $request->setSort($options['sort']);
   }
+  else{
+    $sort = variable_get('ting_sort_default','rank_frequency');
+    $request->setSort($sort);
+  }
+
   if (isset($options['collectionType'])) {
     $request->setCollectionType($options['collectionType']);
   }
@@ -294,11 +299,6 @@ function ting_do_search($query, $page = 1, $results_per_page = 10, $options = ar
       $request->userDefinedRanking = array('tieValue' => 0.1, 'rankField' => $fields);
     }
   }
-  // Otherwise, use the ranking setting.
-  else {
-    $request->setRank((isset($options['rank']) && $options['rank']) ? $options['rank'] : 'rank_general');
-  }
-
   // Apply custom boosts if any.
   $boosts = variable_get('ting_boost_fields', array());
 

--- a/ting.client.inc
+++ b/ting.client.inc
@@ -256,7 +256,7 @@ function ting_do_search($query, $page = 1, $results_per_page = 10, $options = ar
     $request->setSort($options['sort']);
   }
   else{
-    $sort = variable_get('ting_sort_default','rank_frequency');
+    $sort = variable_get('ting_sort_default', 'rank_frequency');
     $request->setSort($sort);
   }
 

--- a/ting.module
+++ b/ting.module
@@ -350,7 +350,27 @@ function ting_element_info() {
       '#input' => TRUE,
       '#process' => array('ting_ranking_field_element_process'),
     ),
+    'ting_sort_default' => array(
+      '#input' => TRUE,
+      '#process' => array('ting_sort_default'),
+    )
   );
+}
+
+function ting_sort_default($element, $form_state){
+  $element['#tree'] = TRUE;
+
+  $element['sort_type'] = array(
+    '#title' => t('Type'),
+    '#type' => 'select',
+    '#options' => array(
+      'rank_frequency' => t('rank_frequency'),
+      'rank_general' => t('rank_general'),
+      'rank_none' => t('rank_none'),
+    ),
+    '#default_value' => (isset($element['#value']['sort_type'])) ? $element['#value']['sort_type'] : 'rank_frequency',
+  );
+  return $element;
 }
 
 /**

--- a/ting.module
+++ b/ting.module
@@ -357,6 +357,9 @@ function ting_element_info() {
   );
 }
 
+/**
+ * Processor for the ting_sort_default form element.
+ */
 function ting_sort_default($element, $form_state){
   $element['#tree'] = TRUE;
 
@@ -364,9 +367,9 @@ function ting_sort_default($element, $form_state){
     '#title' => t('Type'),
     '#type' => 'select',
     '#options' => array(
-      'rank_frequency' => t('rank_frequency'),
-      'rank_general' => t('rank_general'),
-      'rank_none' => t('rank_none'),
+      'rank_frequency' => t('Best match'),
+      'rank_general' => t('General Rank'),
+      'rank_none' => t('No rank'),
     ),
     '#default_value' => (isset($element['#value']['sort_type'])) ? $element['#value']['sort_type'] : 'rank_frequency',
   );

--- a/ting.module
+++ b/ting.module
@@ -350,31 +350,9 @@ function ting_element_info() {
       '#input' => TRUE,
       '#process' => array('ting_ranking_field_element_process'),
     ),
-    'ting_sort_default' => array(
-      '#input' => TRUE,
-      '#process' => array('ting_sort_default'),
-    )
   );
 }
 
-/**
- * Processor for the ting_sort_default form element.
- */
-function ting_sort_default($element, $form_state){
-  $element['#tree'] = TRUE;
-
-  $element['sort_type'] = array(
-    '#title' => t('Type'),
-    '#type' => 'select',
-    '#options' => array(
-      'rank_frequency' => t('Best match'),
-      'rank_general' => t('General Rank'),
-      'rank_none' => t('No rank'),
-    ),
-    '#default_value' => (isset($element['#value']['sort_type'])) ? $element['#value']['sort_type'] : 'rank_frequency',
-  );
-  return $element;
-}
 
 /**
  * Implements hook_theme().


### PR DESCRIPTION
...admin/config/ting/ranking

When searching user can select sort-method. If 'best match' is chosen sort parameter is set according to setting in admin/ting/ranking/Default sort method (best match)

besides that <rank> is not valid since os.3.1, so it dies here