### PR TITLE
Issue796 by Pjohans: if ding_provider fails to translate an old pid - tr...

### DIFF
--- a/ting.module
+++ b/ting.module
@@ -618,9 +618,12 @@ function ting_object_load($id) {
   $agency = variable_get('ting_agency', FALSE);
   if ($agency && preg_match('/^(\d{6}):(\w+)$/', $id, $matches)) {
     // Matched to data well version 2, to redirect to version 3.
-    $id = ding_provider_build_entity_id($matches[2], $matches[1]);
-    if($id === FALSE){
+    $new_id = ding_provider_build_entity_id($matches[2], $matches[1]);
+    if($new_id === FALSE){
       $id = ting_lookup_and_translate($id);
+    }
+    else{
+      $id = $new_id;
     }
     drupal_goto('ting/object/' . $id, array(), 301);
   }
@@ -674,9 +677,12 @@ function ting_collection_load($id) {
   $agency = variable_get('ting_agency', FALSE);
   if ($agency && preg_match('/^(\d{6}):(\w+)$/', $id, $matches)) {
     // Matched to data well version 2, to redirect to version 3.
-    $id = ding_provider_build_entity_id($matches[2], $matches[1]);
-    if($id === FALSE){
+    $new_id = ding_provider_build_entity_id($matches[2], $matches[1]);
+    if($new_id === FALSE){
       $id = ting_lookup_and_translate($id);
+    }
+    else{
+      $id = $new_id;
     }
     drupal_goto('ting/collection/' . $id, array(), 301);
   }

--- a/ting.module
+++ b/ting.module
@@ -619,11 +619,39 @@ function ting_object_load($id) {
   if ($agency && preg_match('/^(\d{6}):(\w+)$/', $id, $matches)) {
     // Matched to data well version 2, to redirect to version 3.
     $id = ding_provider_build_entity_id($matches[2], $matches[1]);
+    if($id === FALSE){
+      $id = ting_lookup_and_translate($id);
+    }
     drupal_goto('ting/object/' . $id, array(), 301);
   }
 
   return ding_entity_load($id, 'ting_object');
 }
+
+
+/**
+ * Try to lookup well3 pid via a search on the old pid.
+ * Search query is constructed from old pid eg. 870971:72966643 -> '870971 and 72966643'
+ *
+ * This is NOT foolproof - if more than one result is found the first is returned, and that might not
+ * be the correct one
+ *
+ * @param $old_pid ( eg 870971:72966643)
+ * @return bool|mixed; new pid (eg  870971-tsart:72966643 ) if found; else FALSE
+ */
+function ting_lookup_and_translate($old_pid){
+  $query_elements = explode(':', $old_pid);
+  $query = implode(' and ', $query_elements);
+
+  module_load_include('client.inc', 'ting');
+  $result = ting_do_search($query,1,1,array('facets'=>array()));
+  if(isset($result->collections)) {
+    $id = key($result->collections);
+    return $id;
+  }
+  return FALSE;
+}
+
 
 /**
  * Load multiple ting objects.
@@ -647,6 +675,9 @@ function ting_collection_load($id) {
   if ($agency && preg_match('/^(\d{6}):(\w+)$/', $id, $matches)) {
     // Matched to data well version 2, to redirect to version 3.
     $id = ding_provider_build_entity_id($matches[2], $matches[1]);
+    if($id === FALSE){
+      $id = ting_lookup_and_translate($id);
+    }
     drupal_goto('ting/collection/' . $id, array(), 301);
   }
 

--- a/ting.module
+++ b/ting.module
@@ -573,8 +573,8 @@ function ting_collection_page_view($object) {
 
 /**
  * Page title callback.
- * 
- * Strips chars '<' and '>' in order to avoid HTML injections. 
+ *
+ * Strips chars '<' and '>' in order to avoid HTML injections.
  */
 function ting_page_title($object) {
   return str_replace('&amp;', '&', htmlspecialchars($object->title, ENT_NOQUOTES, 'UTF-8'));
@@ -619,10 +619,10 @@ function ting_object_load($id) {
   if ($agency && preg_match('/^(\d{6}):(\w+)$/', $id, $matches)) {
     // Matched to data well version 2, to redirect to version 3.
     $new_id = ding_provider_build_entity_id($matches[2], $matches[1]);
-    if($new_id === FALSE){
+    if ($new_id === FALSE) {
       $id = ting_lookup_and_translate($id);
     }
-    else{
+    else {
       $id = $new_id;
     }
     drupal_goto('ting/object/' . $id, array(), 301);
@@ -642,13 +642,13 @@ function ting_object_load($id) {
  * @param $old_pid ( eg 870971:72966643)
  * @return bool|mixed; new pid (eg  870971-tsart:72966643 ) if found; else FALSE
  */
-function ting_lookup_and_translate($old_pid){
+function ting_lookup_and_translate($old_pid) {
   $query_elements = explode(':', $old_pid);
   $query = implode(' and ', $query_elements);
 
   module_load_include('client.inc', 'ting');
-  $result = ting_do_search($query,1,1,array('facets'=>array()));
-  if(isset($result->collections)) {
+  $result = ting_do_search($query, 1, 1, array('facets' => array()));
+  if (!empty($result->collections)) {
     $id = key($result->collections);
     return $id;
   }
@@ -678,10 +678,10 @@ function ting_collection_load($id) {
   if ($agency && preg_match('/^(\d{6}):(\w+)$/', $id, $matches)) {
     // Matched to data well version 2, to redirect to version 3.
     $new_id = ding_provider_build_entity_id($matches[2], $matches[1]);
-    if($new_id === FALSE){
+    if ($new_id === FALSE) {
       $id = ting_lookup_and_translate($id);
     }
-    else{
+    else {
       $id = $new_id;
     }
     drupal_goto('ting/collection/' . $id, array(), 301);


### PR DESCRIPTION
...y to look it up via opensearch

ding_provider:.ding_provider_build_entity_id() does a very good effort to tranlate old pid's  to new ones. It is not always possible though.

 According to the clever heads around here 95% of the pid's will be handled. The rest will fall through. This solution looks the rest up runtime with a searchrequest