### PR TITLE
Implemented custom labels for material types.

### DIFF
--- a/ting.admin.inc
+++ b/ting.admin.inc
@@ -104,6 +104,56 @@ function ting_admin_ting_settings($form_state) {
 }
 
 /**
+ * Form builder; Configure custom names for ting types.
+ *
+ * @ingroup forms
+ * @see system_settings_form()
+ */
+function ting_admin_types_settings($form_state) {
+  form_load_include($form_state, 'inc', 'ting', 'ting.admin');
+  form_load_include($form_state, 'inc', 'ting', 'ting.client');
+  $form = array();
+
+  $form['update'] = array(
+    '#type' => 'fieldset',
+    '#title' => t('Update from datawell'),
+    '#description' => t('Update the list of known types by asking the datawell for all types.'),
+  );
+
+  $form['update']['update'] = array(
+    '#type' => 'submit',
+    '#value' => t('Update'),
+    '#submit' => array('ting_admin_update_types'),
+  );
+
+  $types = variable_get('ting_well_types', _ting_fetch_well_types());
+
+  $settings = variable_get('ting_type_labels', array());
+  $form['ting_type_labels'] = array(
+    '#type' => 'fieldset',
+    '#title' => t('Type labels'),
+    '#tree' => TRUE,
+    '#description' => t("Here you may override the default label for individual material types."),
+  );
+
+  if (count($types)) {
+    foreach ($types as $term => $count) {
+      $form['ting_type_labels'][$term] = array(
+        '#type' => 'textfield',
+        '#title' => $term,
+        '#default_value' => isset($settings[$term]) ? $settings[$term] : '',
+        '#description' => t('Count: @count', array('@count' => $count)),
+        // Fudge the parent so we'll get all the labels in one big array in
+        // ting_url_labels.
+        //'#parents' => array('ting_type_labels', $term),
+      );
+    }
+  }
+
+  return system_settings_form($form);
+}
+
+/**
  * Form builder; Configure custom search result ranking for this site.
  *
  * @ingroup forms
@@ -398,7 +448,7 @@ function ting_admin_online_types_settings($form_state) {
   $form['update']['update'] = array(
     '#type' => 'submit',
     '#value' => t('Update'),
-    '#submit' => array('ting_admin_online_types_settings_update_types'),
+    '#submit' => array('ting_admin_update_types'),
   );
 
   $types = variable_get('ting_well_types', _ting_fetch_well_types());
@@ -461,7 +511,7 @@ function ting_admin_online_types_settings($form_state) {
 /**
  * Submit handler. Updates the list of known types from the data well.
  */
-function ting_admin_online_types_settings_update_types($form, &$form_state) {
+function ting_admin_update_types($form, &$form_state) {
   _ting_fetch_well_types();
 }
 

--- a/ting.field.inc
+++ b/ting.field.inc
@@ -298,7 +298,7 @@ function ting_field_formatter_view($entity_type, $entity, $field, $instance, $la
 
     foreach ($entity->types as $type) {
       $element[0][$type] = array(
-        '#prefix' => '<h2>' . $type . '</h2><a name="' . $type . '"></a>',
+        '#prefix' => '<h2>' . ting_type_label($type) . '</h2><a name="' . $type . '"></a>',
       );
     }
     foreach ($entities as $sub_entity) {
@@ -344,7 +344,7 @@ function ting_field_formatter_view($entity_type, $entity, $field, $instance, $la
             'title' => array(
               // @todo: this could be moved into a theme function to be more
               // generic.
-              '#prefix' => '<span class="search-result--heading-type">' . $ting_type . ':</span>',
+              '#prefix' => '<span class="search-result--heading-type">' . ting_type_label($ting_type) . ':</span>',
               '#markup' => $title,
             ),
           );
@@ -363,7 +363,7 @@ function ting_field_formatter_view($entity_type, $entity, $field, $instance, $la
           '#theme' => 'item_list',
           '#items' => array(
             array(
-              'data' => $entity->type,
+              'data' => ting_type_label($entity->type),
               'class' => array(drupal_html_class($entity->type)),
             ),
           ),
@@ -443,7 +443,7 @@ function ting_field_formatter_view($entity_type, $entity, $field, $instance, $la
         $types = array();
         foreach ($entity->types as $type) {
           $types[] = array(
-            'data' => $type,
+            'data' => ting_type_label($type),
             'class' => array(drupal_html_class($type)),
           );
         }

--- a/ting.module
+++ b/ting.module
@@ -97,6 +97,16 @@ function ting_menu() {
     'file' => 'ting.admin.inc',
   );
 
+  $items['admin/config/ting/types'] = array(
+    'title' => 'Types',
+    'description' => 'Configure custom names for ting types.',
+    'weight' => -10,
+    'page callback' => 'drupal_get_form',
+    'page arguments' => array('ting_admin_types_settings'),
+    'access arguments' => array('administer ting settings'),
+    'file' => 'ting.admin.inc',
+  );
+
   $items['admin/config/ting/ranking'] = array(
     'title' => 'Search result ranking',
     'description' => 'Provides settings for how search results are ranked.',
@@ -294,7 +304,7 @@ function ting_block_view($delta = '') {
         $block->subject = t('Other materialtypes');
         $items = array();
         foreach ($collection->types as $type) {
-          $items[] = l($type . ' (' . $collection->types_count[$type] . ')', '#' . $type, array('external' => TRUE));
+          $items[] = l(ting_type_label($type) . ' (' . $collection->types_count[$type] . ')', '#' . $type, array('external' => TRUE));
         }
         $block->content = array(
           '#theme' => 'item_list',
@@ -311,7 +321,7 @@ function ting_block_view($delta = '') {
           $uri = entity_uri('ting_collection', $collection);
           $uri['options']['fragment'] = _ting_anchor_name($type);
           $uri['options']['attributes'] = array('class' => array('js-search-overlay'));
-          $items[] = l($type . ' (' . $collection->types_count[$type] . ')', $uri['path'], $uri['options']);
+          $items[] = l(ting_type_label($type) . ' (' . $collection->types_count[$type] . ')', $uri['path'], $uri['options']);
         }
 
         // Only display block if there are more than on item.
@@ -1058,4 +1068,17 @@ function _ting_anchor_name($type) {
   $name = str_replace(':', '', $name);
   $name = strtolower($name);
   return $name;
+}
+
+/**
+ * Return the label for a material type.
+ */
+function ting_type_label($type) {
+  $types = variable_get('ting_type_labels', array());
+  $lc_type = drupal_strtolower($type);
+  if (isset($types[$lc_type]) && !empty($types[$lc_type])) {
+    return $types[$lc_type];
+  }
+
+  return $type;
 }


### PR DESCRIPTION
Allows for configuring the labels used for ting object types in the frontend, so "lydbog (net)" can be displayed as "Lydbog", for instance.
